### PR TITLE
added ability to define aws_type_nodes

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -7,7 +7,7 @@ px_version: 2.4.0
 stop_after: 6
 post_script: show-ip
 
-aws_region: eu-west-1
+aws_region: us-east-1
 aws_type: t3.large
 aws_ebs: "gp2:20"
 #aws_ebs: "gp2:20 standard:30"

--- a/px-deploy.go
+++ b/px-deploy.go
@@ -34,7 +34,7 @@ type Config struct {
   Post_Script string
   Auto_Destroy string
   Aws_Type string
-  Aws_Type_Nodes string
+  Aws_Type_Cluster_1_Worker_Nodes string
   Aws_Ebs string
   Gcp_Type string
   Gcp_Disks string
@@ -53,7 +53,7 @@ type Config struct {
 }
 
 func main() {
-  var createName, createPlatform, createClusters, createNodes, createK8sVer, createPxVer, createStopAfter, createAwsType, createAwsTypeNodes, createAwsEbs, createGcpType, createGcpDisks, createGcpZone, createTemplate, createRegion, createCloud, createEnv, connectName, destroyName, statusName string
+  var createName, createPlatform, createClusters, createNodes, createK8sVer, createPxVer, createStopAfter, createAwsType, createAwsTypeWorker1WokerNodes, createAwsEbs, createGcpType, createGcpDisks, createGcpZone, createTemplate, createRegion, createCloud, createEnv, connectName, destroyName, statusName string
   var destroyAll bool
   os.Chdir("/px-deploy/.px-deploy")
   rootCmd := &cobra.Command{Use: "px-deploy"}
@@ -130,9 +130,9 @@ func main() {
         if (!regexp.MustCompile(`^[0-9a-z\.]+$`).MatchString(createAwsType)) { die("Invalid AWS type '" + createAwsType + "'") }
         config.Aws_Type = createAwsType
       }
-      if (createAwsTypeNodes != "") {
+      if (createAwsTypeWorker1WokerNodes != "") {
         if (!regexp.MustCompile(`^[0-9a-z\.]+$`).MatchString(createAwsType)) { die("Invalid AWS type '" + createAwsType + "'") }
-        config.Aws_Type_Nodes = createAwsTypeNodes
+        config.Aws_Type_Cluster_1_Worker_Nodes = createAwsTypeWorker1WokerNodes
       }
       if (createAwsEbs != "") {
         if (!regexp.MustCompile(`^[0-9a-z\ :]+$`).MatchString(createAwsEbs)) { die("Invalid AWS EBS volumes '" + createAwsEbs + "'") }
@@ -294,7 +294,7 @@ func main() {
   cmdCreate.Flags().StringVarP(&createPxVer, "px_version", "P", "", "Portworx version to be deployed (default " + defaults.Px_Version + ")")
   cmdCreate.Flags().StringVarP(&createStopAfter, "stop_after", "s", "", "Stop instances after this many hours (default " + defaults.Stop_After + ")")
   cmdCreate.Flags().StringVarP(&createAwsType, "aws_type", "", "", "AWS type for each node (default " + defaults.Aws_Type + ")")
-  cmdCreate.Flags().StringVarP(&createAwsTypeNodes, "aws_type_nodes", "", "", "AWS type for each node of first cluster (default " + defaults.Aws_Type + ")")
+  cmdCreate.Flags().StringVarP(&createAwsTypeWorker1WokerNodes, "Aws_Type_Cluster_1_Worker_Nodes", "", "", "AWS type for each node of first cluster (default " + defaults.Aws_Type + ")")
   cmdCreate.Flags().StringVarP(&createAwsEbs, "aws_ebs", "", "", "space-separated list of EBS volumes to be attached to worker nodes, eg \"gp2:20 standard:30\" (default " + defaults.Aws_Ebs + ")")
   cmdCreate.Flags().StringVarP(&createGcpType, "gcp_type", "", "", "GCP type for each node (default " + defaults.Gcp_Type + ")")
   cmdCreate.Flags().StringVarP(&createGcpDisks, "gcp_disks", "", "", "space-separated list of EBS volumes to be attached to worker nodes, eg \"pd-standard:20 pd-ssd:30\" (default " + defaults.Gcp_Disks + ")")
@@ -328,8 +328,8 @@ func create_deployment(config Config) int {
         yes | ssh-keygen -q -t rsa -b 2048 -f keys/id_rsa.aws.` + config.Name + ` -N ''
         aws ec2 describe-instance-types --instance-types ` + config.Aws_Type + `>&/dev/null
         [ $? -ne 0 ] && echo "Invalid AWS type '` + config.Aws_Type + `' for region '` + config.Aws_Region + `'" && exit 1
-        aws ec2 describe-instance-types --instance-types ` + config.Aws_Type_Nodes + `>&/dev/null
-        [ $? -ne 0 ] && echo "Invalid AWS type '` + config.Aws_Type_Nodes + `' for region '` + config.Aws_Region + `'" && exit 1
+        aws ec2 describe-instance-types --instance-types ` + config.Aws_Type_Cluster_1_Worker_Nodes + `>&/dev/null
+        [ $? -ne 0 ] && echo "Invalid AWS type '` + config.Aws_Type_Cluster_1_Worker_Nodes + `' for region '` + config.Aws_Region + `'" && exit 1
         aws ec2 delete-key-pair --key-name px-deploy.` + config.Name + ` >&/dev/null
         aws ec2 import-key-pair --key-name px-deploy.` + config.Name + ` --public-key-material file://keys/id_rsa.aws.` + config.Name + `.pub >&/dev/null
         _AWS_vpc=$(aws --output text ec2 create-vpc --cidr-block 192.168.0.0/16 --query Vpc.VpcId)

--- a/px-deploy.go
+++ b/px-deploy.go
@@ -34,6 +34,7 @@ type Config struct {
   Post_Script string
   Auto_Destroy string
   Aws_Type string
+  Aws_Type_Nodes string
   Aws_Ebs string
   Gcp_Type string
   Gcp_Disks string
@@ -52,7 +53,7 @@ type Config struct {
 }
 
 func main() {
-  var createName, createPlatform, createClusters, createNodes, createK8sVer, createPxVer, createStopAfter, createAwsType, createAwsEbs, createGcpType, createGcpDisks, createGcpZone, createTemplate, createRegion, createCloud, createEnv, connectName, destroyName, statusName string
+  var createName, createPlatform, createClusters, createNodes, createK8sVer, createPxVer, createStopAfter, createAwsType, createAwsTypeNodes, createAwsEbs, createGcpType, createGcpDisks, createGcpZone, createTemplate, createRegion, createCloud, createEnv, connectName, destroyName, statusName string
   var destroyAll bool
   os.Chdir("/px-deploy/.px-deploy")
   rootCmd := &cobra.Command{Use: "px-deploy"}
@@ -128,6 +129,10 @@ func main() {
       if (createAwsType != "") {
         if (!regexp.MustCompile(`^[0-9a-z\.]+$`).MatchString(createAwsType)) { die("Invalid AWS type '" + createAwsType + "'") }
         config.Aws_Type = createAwsType
+      }
+      if (createAwsTypeNodes != "") {
+        if (!regexp.MustCompile(`^[0-9a-z\.]+$`).MatchString(createAwsType)) { die("Invalid AWS type '" + createAwsType + "'") }
+        config.Aws_Type_Nodes = createAwsTypeNodes
       }
       if (createAwsEbs != "") {
         if (!regexp.MustCompile(`^[0-9a-z\ :]+$`).MatchString(createAwsEbs)) { die("Invalid AWS EBS volumes '" + createAwsEbs + "'") }
@@ -289,6 +294,7 @@ func main() {
   cmdCreate.Flags().StringVarP(&createPxVer, "px_version", "P", "", "Portworx version to be deployed (default " + defaults.Px_Version + ")")
   cmdCreate.Flags().StringVarP(&createStopAfter, "stop_after", "s", "", "Stop instances after this many hours (default " + defaults.Stop_After + ")")
   cmdCreate.Flags().StringVarP(&createAwsType, "aws_type", "", "", "AWS type for each node (default " + defaults.Aws_Type + ")")
+  cmdCreate.Flags().StringVarP(&createAwsTypeNodes, "aws_type_nodes", "", "", "AWS type for each node of first cluster (default " + defaults.Aws_Type + ")")
   cmdCreate.Flags().StringVarP(&createAwsEbs, "aws_ebs", "", "", "space-separated list of EBS volumes to be attached to worker nodes, eg \"gp2:20 standard:30\" (default " + defaults.Aws_Ebs + ")")
   cmdCreate.Flags().StringVarP(&createGcpType, "gcp_type", "", "", "GCP type for each node (default " + defaults.Gcp_Type + ")")
   cmdCreate.Flags().StringVarP(&createGcpDisks, "gcp_disks", "", "", "space-separated list of EBS volumes to be attached to worker nodes, eg \"pd-standard:20 pd-ssd:30\" (default " + defaults.Gcp_Disks + ")")
@@ -322,6 +328,8 @@ func create_deployment(config Config) int {
         yes | ssh-keygen -q -t rsa -b 2048 -f keys/id_rsa.aws.` + config.Name + ` -N ''
         aws ec2 describe-instance-types --instance-types ` + config.Aws_Type + `>&/dev/null
         [ $? -ne 0 ] && echo "Invalid AWS type '` + config.Aws_Type + `' for region '` + config.Aws_Region + `'" && exit 1
+        aws ec2 describe-instance-types --instance-types ` + config.Aws_Type_Nodes + `>&/dev/null
+        [ $? -ne 0 ] && echo "Invalid AWS type '` + config.Aws_Type_Nodes + `' for region '` + config.Aws_Region + `'" && exit 1
         aws ec2 delete-key-pair --key-name px-deploy.` + config.Name + ` >&/dev/null
         aws ec2 import-key-pair --key-name px-deploy.` + config.Name + ` --public-key-material file://keys/id_rsa.aws.` + config.Name + `.pub >&/dev/null
         _AWS_vpc=$(aws --output text ec2 create-vpc --cidr-block 192.168.0.0/16 --query Vpc.VpcId)

--- a/scripts/central
+++ b/scripts/central
@@ -8,6 +8,11 @@ if [ $cluster = 1 ]; then
     IP=$(curl https://ipinfo.io/ip)
     curl -o /root/install.sh 'https://raw.githubusercontent.com/portworx/px-central-onprem/1.0.1/install.sh'
     sh /root/install.sh --all --license-password 'Adm1n!Ur' --kubeconfig /root/.kube/config --pxcentral-endpoint $IP
+else
+    k8s_version=$(kubectl version --short | awk -Fv '/Server Version: / {print $3}')
+    url="https://install.portworx.com/$px_version?kbver=$k8s_version&b=true&c=px-deploy-$cluster&stork=true&st=k8s"
+    curl -so /tmp/px.yml $url
+    kubectl apply -f /tmp/px.yml
 fi
 
 cat <<EOF > /etc/motd

--- a/templates/px-central.yml
+++ b/templates/px-central.yml
@@ -3,7 +3,7 @@ cloud: aws
 clusters: 2
 nodes: 3
 aws_type: t3.medium
-aws_type_nodes: t3.2xlarge
+aws_type_cluster_1_worker_nodes: t3.2xlarge
 aws_ebs: "gp2:80 gp2:100"
 k8s_version: 1.16.0
 

--- a/templates/px-central.yml
+++ b/templates/px-central.yml
@@ -1,8 +1,9 @@
 description: A single K8s and Portworx cluster with PX-Central Alpha & Grafana installed
 cloud: aws
-clusters: 1
+clusters: 2
 nodes: 3
-aws_type: t3.2xlarge
+aws_type: t3.medium
+aws_type_nodes: t3.2xlarge
 aws_ebs: "gp2:80 gp2:100"
 k8s_version: 1.16.0
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -81,7 +81,7 @@ Vagrant.configure("2") do |config|
         node.vm.hostname = "node-#{c}-#{n}"
         if yaml['cloud'] == "aws"
           node.vm.provider :aws do |aws|
-            aws.instance_type = (c == 1 && yaml['aws_type_nodes'] != nil) ? yaml['aws_type_nodes'] : yaml['aws_type']
+            aws.instance_type = (c == 1 && yaml['aws_type_cluster_1_worker_nodes'] != nil) ? yaml['aws_type_cluster_1_worker_nodes'] : yaml['aws_type']
             aws.private_ip_address = "#{subnet}.#{100+n}"
             aws.tags = { "Name" => "node-#{c}-#{n}", "px-deploy_name" => yaml['name'] }
             d = 97

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure("2") do |config|
         node.vm.hostname = "node-#{c}-#{n}"
         if yaml['cloud'] == "aws"
           node.vm.provider :aws do |aws|
+            aws.instance_type = (c == 1 && yaml['aws_type_nodes'] != nil) ? yaml['aws_type_nodes'] : yaml['aws_type']
             aws.private_ip_address = "#{subnet}.#{100+n}"
             aws.tags = { "Name" => "node-#{c}-#{n}", "px-deploy_name" => yaml['name'] }
             d = 97


### PR DESCRIPTION
adding aws_type_nodes to the template will create worker nodes of a different type, only on the first cluster. Master nodes and nodes of other clusters will keep using aws_type. 