### PR TITLE
Patches px version in aync-dr

### DIFF
--- a/templates/async-dr.yml
+++ b/templates/async-dr.yml
@@ -1,7 +1,7 @@
 description: Deploys 2 clusters with Portworx, sets up and configures a cluster pairing, configures an async DR schedule with a loadbalancer in front of the setup.
 clusters: 2
 scripts: ["install-awscli", "install-px", "licenses"]
-px_version: 2.5.2
+px_version: 2.6.1.6
 cluster:
   - id: 1
     scripts: ["aws-elb", "async-dr", "optional-apps"]


### PR DESCRIPTION
Previous versions had issues retaining deployments when initiating a sync. This meant activating a migration could mean some deployments were missing and had to manually created.