### PR TITLE
Bug fix - Vagrant was creating VM's with same MAC addresses. Add conf…

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -74,6 +74,7 @@ Vagrant.configure("2") do |config|
   elsif yaml['cloud'] == "vsphere"
     config.vm.box = "FEBO/centos7"
     config.vm.box_version = "0.1"
+    config.vm.base_mac = nil
     config.vm.provider :vsphere do |vsphere, override|
       vsphere.host = yaml['vsphere_host']
       vsphere.compute_resource_name = yaml['vsphere_compute_resource']


### PR DESCRIPTION
Vagrant was creating VM's with same MAC addresses.
Add 

config.vm.base_mac = nil 

to Vagrantfile to fix this.

https://www.vagrantup.com/docs/vagrantfile/machine_settings