### PR TITLE
Updated wordpress.yaml

### DIFF
--- a/assets/wordpress/wordpress.yml
+++ b/assets/wordpress/wordpress.yml
@@ -5,7 +5,7 @@ metadata:
 provisioner: kubernetes.io/portworx-volume
 parameters:
   repl: "2"
-  shared: "true"
+  sharedv4: "true"
 allowVolumeExpansion: true
 ---
 apiVersion: v1


### PR DESCRIPTION
Deprecating shared in favour of sharedv4. This is a diplomatic commit message. There were other issues but Luay wouldn't let me include them in this message. Life goes on.