### PR TITLE
Joeg/updates

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -2,7 +2,7 @@ cloud: aws
 platform: k8s
 clusters: 1
 nodes: 3
-k8s_version: 1.17.0
+k8s_version: 1.19.0
 px_version: 2.7.0
 stop_after: 6
 post_script: show-ip
@@ -10,7 +10,7 @@ quiet: false
 
 aws_region: eu-west-1
 aws_type: t3.large
-aws_ebs: "gp2:20"
+aws_ebs: "gp2:50"
 #aws_ebs: "gp2:20 standard:30"
 
 gcp_region: europe-west1

--- a/defaults.yml
+++ b/defaults.yml
@@ -2,7 +2,7 @@ cloud: aws
 platform: k8s
 clusters: 1
 nodes: 3
-k8s_version: 1.19.0
+k8s_version: 1.19.9
 px_version: 2.7.0
 stop_after: 6
 post_script: show-ip

--- a/scripts/install-px
+++ b/scripts/install-px
@@ -96,7 +96,7 @@ done
 curl -so /tmp/px.yml $url
 kubectl apply -f /tmp/px.yml
 
-curl -sL https://github.com/portworx/pxc/releases/download/v0.30.0/pxc-v0.30.0.linux.amd64.tar.gz | tar xvz -C /tmp/.
+curl -sL https://github.com/portworx/pxc/releases/download/v0.33.0/pxc-v0.33.0.linux.amd64.tar.gz | tar xvz -C /tmp/.
 mv /tmp/pxc/kubectl-pxc /usr/bin/.
 
 # Install storkctl

--- a/scripts/licenses
+++ b/scripts/licenses
@@ -12,7 +12,7 @@ for i in $licenses; do
 done
 
 for i in $licenses; do
-  while ! kubectl exec -n kube-system -it $(kubectl get pods -n kube-system -lname=portworx --field-selector=status.phase=Running | tail -1 | cut -f 1 -d " ") -- /opt/pwx/bin/pxctl license activate --ep UAT $i; do
+  while ! kubectl exec -n kube-system -it $(kubectl get pods -n kube-system -lname=portworx --field-selector=status.phase=Running | tail -1 | cut -f 1 -d " ") -- /opt/pwx/bin/pxctl license activate $i; do
     sleep 1
   done
 done

--- a/templates/async-dr.yml
+++ b/templates/async-dr.yml
@@ -1,7 +1,6 @@
 description: Deploys 2 clusters with Portworx, sets up and configures a cluster pairing, configures an async DR schedule with a loadbalancer in front of the setup.
 clusters: 2
 scripts: ["install-awscli", "install-px", "licenses"]
-px_version: 2.6.2.1
 cluster:
   - id: 1
     scripts: ["aws-elb", "async-dr", "optional-apps"]

--- a/templates/autopilot.yml
+++ b/templates/autopilot.yml
@@ -1,7 +1,7 @@
 description: Deploys a Kubernetes cluster and Portworx with Promethues and Autopilot pre-configured.
 cloud: aws
 clusters: 1
-scripts: ["install-px", "autopilot", "licenses"]
+scripts: ["install-px", "autopilot"]
 env:
   #licenses: "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
   px_suffix: "mon=true"


### PR DESCRIPTION
- adds latest PX version and updates K8s to 1.19.0 - tested with all the demos
- updates the license script prior to sharing the new key with px-deploy users
- updates the pxc version in preparation for px-security being enabled by default
- removes version pin in async-dr demo
- removes licenses script from autopilot now it is included in the 30 day trial

This needs to be pushed as a new release to resolve the licensing issue.