### PR TITLE
Updates the metro schedule

### DIFF
--- a/assets/metro-schedule.yml
+++ b/assets/metro-schedule.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 policy:
   interval:
-    intervalMinutes: 1
+    intervalMinutes: 2
 ---
 apiVersion: stork.libopenstorage.org/v1alpha1
 kind: MigrationSchedule


### PR DESCRIPTION
On some occasions a resource will be recreated during a simulated failure causing the migration to  miss this resource requiring a manual deployment. Expanding the schedule should reduce the likelihood of this. It is an issue in the migration schedule behaviour though and will hopefully be fixed in a future PX release.