### PR TITLE
Update clusterpair-metro

### DIFF
--- a/scripts/clusterpair-metro
+++ b/scripts/clusterpair-metro
@@ -6,7 +6,7 @@ while : ; do
   sleep 5
   echo waiting for portworx
 done
-storkctl generate clusterpair -n default remotecluster-$cluster | sed '/insert_storage_options_here/c\' >/var/tmp/cp.yaml
+storkctl generate clusterpair -n kube-system remotecluster-$cluster | sed '/insert_storage_options_here/c\' >/var/tmp/cp.yaml
 while : ; do
   cat /var/tmp/cp.yaml | ssh -oConnectTimeout=1 -oStrictHostKeyChecking=no master-1 kubectl apply -f -
   [ $? -eq 0 ] && break


### PR DESCRIPTION
Generates the pairing in the kube-system namespace to allow for more complex, multi-namespace failover demos.