### PR TITLE
Vsphere etc hosts fix

### DIFF
--- a/vagrant/all-common
+++ b/vagrant/all-common
@@ -67,6 +67,7 @@ elif [ $cloud = "vsphere" ]; then
     done
     [ $(wc -l /tmp/hosts | cut -f 1 -d " ") -eq $[($nodes+1)*$clusters] ] && break
   done
+  echo 127.0.0.1 localhost >/etc/hosts
   cat /tmp/hosts >>/etc/hosts
 fi
 

--- a/vagrant/all-common
+++ b/vagrant/all-common
@@ -65,7 +65,7 @@ elif [ $cloud = "vsphere" ]; then
     for i in $(govc find / -type m -runtime.powerState poweredOn | egrep "vagrant_$name-(master|node)"); do
       govc vm.info -json "$i" | jq -r '.VirtualMachines[0].Config.ExtraConfig[] | select(.Key==("guestinfo.local-ipv4","pxd.hostname")).Value' 2>/dev/null | paste -d " " - - | awk '{print $2,$1}' >>/tmp/hosts
     done
-    [ $(wc -l /tmp/hosts | cut -f 1 -d " ") -eq $[($nodes+1)*$clusters] ] && break
+    [ $(cat /tmp/hosts | wc -w) -eq $[($nodes+1)*$clusters*2] ] && break
   done
   echo 127.0.0.1 localhost >/etc/hosts
   cat /tmp/hosts >>/etc/hosts


### PR DESCRIPTION
Fixes two issues with creation of /etc/hosts on each node (affected vsphere code only):

1. Race condition where we could pick up a host that doesn't yet have an IP, creating a malformed hosts file
2. Issue with certain hosts that report multiple IP addresses for `hostname -i`, mangling the hosts file. 