### PR TITLE
create vpc subnet for each cluster

### DIFF
--- a/px-deploy.go
+++ b/px-deploy.go
@@ -771,8 +771,8 @@ func create_deployment(config Config) int {
 			masternum := strconv.Itoa(c)
 			net := strconv.Itoa(c+100)
 			tf_var_masters = append(tf_var_masters,"  master-"+masternum+" = {")
-			tf_var_masters = append(tf_var_masters,"    ip_address= \""+subnet+net+".90\"")
-			tf_var_masters = append(tf_var_masters,"    cluster= \""+masternum+"\"")
+			tf_var_masters = append(tf_var_masters,"    ip_address = \""+subnet+net+".90\"")
+			tf_var_masters = append(tf_var_masters,"    cluster = "+masternum)
 			tf_var_masters = append(tf_var_masters,"  }")
 			tf_master_script = tf_common_master_script
 			tf_cluster_aws_type = config.Aws_Type
@@ -818,7 +818,7 @@ func create_deployment(config Config) int {
 				tf_var_nodes = append(tf_var_nodes,"  node-"+masternum+"-"+nodenum+" = { ")
 				tf_var_nodes = append(tf_var_nodes,"    ip_address    = \""+subnet+net+"."+nodeip+"\"")
 				tf_var_nodes = append(tf_var_nodes,"    instance_type = \""+tf_cluster_aws_type+"\"")
-				tf_var_nodes = append(tf_var_nodes,"    cluster = \""+masternum+"\"")
+				tf_var_nodes = append(tf_var_nodes,"    cluster = "+masternum)
 				tf_var_nodes = append(tf_var_nodes,"  }")
 				
 				tf_individual_node_script = tf_node_script
@@ -851,6 +851,7 @@ func create_deployment(config Config) int {
 
 		// build terraform variable file
 		tf_variables = append (tf_variables, "config_name = \"" + config.Name + "\"")
+		tf_variables = append (tf_variables, "clusters = " + config.Clusters)
 		tf_variables = append (tf_variables, "aws_region = \"" + config.Aws_Region + "\"")
 		tf_variables = append (tf_variables, "aws_instance_type = \"" + config.Aws_Type + "\"")
 		tf_variables = append (tf_variables, "masters = {")

--- a/terraform/awstf/aws-returns.tpl
+++ b/terraform/awstf/aws-returns.tpl
@@ -1,7 +1,6 @@
 
 aws__vpc: ${tpl_vpc}
 aws__sg: ${tpl_sg}
-aws__subnet:  ${tpl_subnet}
 aws__gw:  ${tpl_gw}
 aws__routetable:  ${tpl_routetable}
 aws__ami:  ${tpl_ami}

--- a/terraform/awstf/variables.tf
+++ b/terraform/awstf/variables.tf
@@ -15,6 +15,11 @@ variable "config_name" {
 	type 		= string
 }
 
+variable "clusters" {
+	description 	= "number of clusters to create"
+	type			= number
+}
+
 variable "aws_instance_type" {
 	description = "aws instance type for vm"
 	type 		= string
@@ -30,7 +35,7 @@ variable "masters" {
 	description 	=  "master names , IPs cluster"
 	type 			= map( object({
 			ip_address 	= string
-			cluster 	= string
+			cluster 	= number
 	}))
 }
 
@@ -39,7 +44,7 @@ variable "nodes" {
 	type 			= map( object({
 		ip_address 		= string
 		instance_type 	= string
-		cluster			= string
+		cluster			= number
 	}))
 }
 


### PR DESCRIPTION
vpc networking re-work for aws terraform. each cluster will have its own subnet (instead of creating single subnet consuming full VPC CIDR). will enable us to create dedicated subnets for openshift or eks within the same VPC