### PR TITLE
Update metro-schedule.yml

### DIFF
--- a/assets/metro-schedule.yml
+++ b/assets/metro-schedule.yml
@@ -20,5 +20,5 @@ spec:
       startApplications: false
       includeVolumes: false
       namespaces:
-      - default
+      - petclinic
   schedulePolicyName: appschedule


### PR DESCRIPTION
I believe petclinic was moved to its own namespace, and during a metro template demo its expecting petclinic to be in default namespace. I do not know if this change will break other demos.