### PR TITLE
Issue 291 predelete

### DIFF
--- a/px-deploy.go
+++ b/px-deploy.go
@@ -1091,7 +1091,6 @@ func destroy_deployment(name string) {
 				}
 				wg.Wait()
 				fmt.Println("pre-delete scripts done")
-die("ende")
 				if len(aws_volumes) > 0 {
 					fmt.Println("Waiting for termination of instances: (timeout 5min)")
 					wg.Add(len(aws_instances))

--- a/px-deploy.go
+++ b/px-deploy.go
@@ -1044,16 +1044,7 @@ func destroy_deployment(name string) {
 				go run_predelete(config.Cloud,config.Name, fmt.Sprintf("master-%v-1",i),"platform")
 			}
 			wg.Wait()
-			fmt.Println("OCP4 cluster delete done")
-			//cmd := exec.Command("/usr/bin/ssh", "-oStrictHostKeyChecking=no", "-i", "keys/id_rsa."+config.Cloud+"."+config.Name, "root@"+ip, `
-			//	for i in $(seq 1 ` + config.Clusters + `); do
-			//  	ssh master-$i "cd /root/ocp4 ; openshift-install destroy cluster"
-			//	done
-			//`)
-			//cmd.Stdout = os.Stdout
-			//cmd.Stderr = os.Stderr
-			//err = cmd.Run()
-			//if (err != nil) { fmt.Println(Yellow + "Failed to destroy OCP4 - please clean up VMs manually: " + err.Error() + Reset) }
+			fmt.Println("OCP4 cluster delete done")			
 			}
 		case "eks": 
 			{

--- a/px-deploy.go
+++ b/px-deploy.go
@@ -1091,7 +1091,7 @@ func destroy_deployment(name string) {
 				}
 				wg.Wait()
 				fmt.Println("pre-delete scripts done")
-
+die("ende")
 				if len(aws_volumes) > 0 {
 					fmt.Println("Waiting for termination of instances: (timeout 5min)")
 					wg.Add(len(aws_instances))
@@ -1299,7 +1299,7 @@ func run_predelete(confCloud string, confName string, confNode string, confPath 
 	fmt.Printf("Running pre-delete scripts on %v (%v)\n",confNode,ip)
 	
 	cmd := exec.Command("/usr/bin/ssh", "-oStrictHostKeyChecking=no", "-i", "keys/id_rsa."+confCloud+"."+confName, "root@"+ip, `
-		for i in /px-deploy/`+confPath+`-delete/*.sh; do bash $i ;done
+		for i in /px-deploy/`+confPath+`-delete/*.sh; do bash $i ;done; exit 0
 	`)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/vagrant/ocp4-master
+++ b/vagrant/ocp4-master
@@ -2,6 +2,11 @@ dnf install -y docker python3-pip epel-release
 dnf install -y jq
 systemctl enable --now docker
 pip3 install awscli
+
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+HELM_INSTALL_DIR=/usr/bin ./get_helm.sh
+
 ln -s /usr/local/bin/aws /usr/bin/aws
 eval $(ssh-agent)
 cd /tmp
@@ -29,6 +34,8 @@ sg=$(cat terraform.cluster.tfstate | jq -r '.resources[] | select(.name==("worke
 aws configure set default.region $aws_region
 aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 17001-17022 --cidr 0.0.0.0/0
 aws ec2 authorize-security-group-ingress --group-id $sg --protocol udp --port 17001-17022 --cidr 0.0.0.0/0
+
+echo "cd /root/ocp4 ; openshift-install destroy cluster" >> /px-deploy/platform-delete/ocp4.sh
 
 URL=$(grep 'Access the OpenShift web-console' /root/ocp4/.openshift_install.log |cut -d\" -f4 | cut -d: -f2-)
 echo "url $URL" >> /var/log/px-deploy/completed/tracking

--- a/vagrant/ocp4-master
+++ b/vagrant/ocp4-master
@@ -30,10 +30,16 @@ if [ $? -ne 0 ]; then
 fi
 mkdir /root/.kube
 cp /root/ocp4/auth/kubeconfig /root/.kube/config
+chmod 600 /root/.kube/config
 sg=$(cat terraform.cluster.tfstate | jq -r '.resources[] | select(.name==("worker") and .type==("aws_security_group")).instances[0].attributes.id')
+
 aws configure set default.region $aws_region
 aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 17001-17022 --cidr 0.0.0.0/0
 aws ec2 authorize-security-group-ingress --group-id $sg --protocol udp --port 17001-17022 --cidr 0.0.0.0/0
+
+# open NFS Port for RWX
+cidr=$(cat terraform.cluster.tfstate | jq -r '.resources[] | select(.name==("private") and .type==("aws_subnet")).instances[0].attributes.cidr_block')
+aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 2049 --cidr $cidr
 
 echo "cd /root/ocp4 ; openshift-install destroy cluster" >> /px-deploy/platform-delete/ocp4.sh
 


### PR DESCRIPTION
scripts can now place their deleting script in /px-deploy/script-delete
will be executed before px-deploy instance destruction

plantforms can now place their deleting script in /px-deploy/platform-delete
will be executed before px-deploy instance destruction (after running destroy script)

during testing fixed issues with ocp4 (nfs RWX not working, blocked by securitygroup)
helm missing

