### PR TITLE
fix aws local zone

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -27,6 +27,10 @@ provider "aws" {
 
 data "aws_availability_zones" "available" {
 	state = "available"
+	filter {
+          name   = "opt-in-status"
+          values = ["opt-in-not-required"]
+        }
 }
 
 data "aws_ami" "rocky" {


### PR DESCRIPTION
on regions with local zones enabled deployment will fail when instances get placed in local zone