### PR TITLE
update ocp4 to 4.12.12

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -49,7 +49,7 @@ vsphere_memory: 8
 vsphere_cpu: 2
 
 ocp4_domain: openshift.portworx.com
-ocp4_version: 4.10.37
+ocp4_version: 4.12.12
 ocp4_pull_secret: XXX
 
 #env:


### PR DESCRIPTION
4.12 is capable of the new px gui plugin

4.12.2 is latest validated release for px, but does not deploy in all aws regions.  aleady tested with 4.12.12