### PR TITLE
fix aws_eip vpc setting

### DIFF
--- a/terraform/aws/ocp4/ocp4.tf
+++ b/terraform/aws/ocp4/ocp4.tf
@@ -32,7 +32,7 @@ resource "aws_vpc_dhcp_options_association" "dns_resolver" {
 }
 
 resource "aws_eip" "nat_gateway" {
-  vpc = true
+  domain     = "vpc"
   depends_on = [aws_internet_gateway.igw]
 }
 


### PR DESCRIPTION
vpc=true is deprecated, change to domain = "vpc" to prevent warning