### PR TITLE
add metadata label for pxstorev2

### DIFF
--- a/px-deploy.go
+++ b/px-deploy.go
@@ -1454,6 +1454,7 @@ func destroy_deployment(name string) {
 							"data",
 							"kvdb",
 							"journal",
+							"metadata",
 						},
 					},
 				},


### PR DESCRIPTION
pxstore v2 uses new "metadata" value for pxtype label.