### PR TITLE
Update install-px

### DIFF
--- a/scripts/install-px
+++ b/scripts/install-px
@@ -40,7 +40,7 @@ EOF
 fi
 
 ctr -n k8s.io images pull docker.io/$(curl -sk https://install.portworx.com/$px_version?comp=stork | awk '/image: openstorage.stork/{print$2}') &
-k8s_version=$(kubectl version --short | awk -Fv '/Server Version: / {print $3}')
+k8s_version=$((kubectl version --short 2>&1 || kubectl version) | awk -Fv '/Server Version: / {print $3}')
 url="https://install.portworx.com/$px_version?kbver=$k8s_version&b=true&c=px-deploy-$cluster&stork=true&st=k8s&lh=true&mon=true&promop=true"
 [ -e /usr/bin/oc ] && url="$url&osft=true"
 if [ "$cloud_drive" ]; then


### PR DESCRIPTION
kubectl version --short is deprecated and is failing on 1.28 
this change is tested on 1.24 and 1.28