### PR TITLE
bump ocp operator to v24.1.1

### DIFF
--- a/scripts/install-px
+++ b/scripts/install-px
@@ -91,7 +91,7 @@ spec:
   name: portworx-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: portworx-operator.v1.10.1
+  startingCSV: portworx-operator.v24.1.1
 EOF
   while ! oc get csv -n portworx  | grep portworx-operator | grep -q Succeeded ; do
     sleep 2


### PR DESCRIPTION
speeds up deployment (ocp will try to install all versions until it reaches current one...)