### PR TITLE
Issue 564 tf init

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/.terraform/
+**/.terraform.lock.hcl


### PR DESCRIPTION
when updating px-deploy newer terraform modules might be included not matching module versions for existing deployments. if we detect missing modules during destroy we're now running 'terraform init' on these deployments again to ensure destruction

fix #564 