### PR TITLE
Update app-migration.yml

### DIFF
--- a/assets/app-migration.yml
+++ b/assets/app-migration.yml
@@ -10,5 +10,6 @@ spec:
   namespaces:
   - pxbbq
   - petclinic
+  - default
 
 


### PR DESCRIPTION
When I do demos of PXe i deploy applications to the default namespace. Adding this back so that it still covers those of us who use the default namespace