### PR TITLE
Add AWS session token support and existing VPC/subnet support

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -12,7 +12,10 @@ aws_region: eu-west-1
 aws_type: t3.large
 aws_ebs: "gp2:50"
 aws_access_key_id: ""
-aws_secret_access_key: "" 
+aws_secret_access_key: ""
+aws_session_token: ""  # Optional: for temporary credentials (IAM Identity Center, STS)
+aws_existing_vpc_id: ""  # Optional: use existing VPC instead of creating new one
+aws_existing_subnet_id: ""  # Optional: use existing subnet (requires aws_existing_vpc_id)
 eks_version: "1.33"
 #aws_ebs: "gp2:20 standard:30"
 

--- a/infra/all-common
+++ b/infra/all-common
@@ -57,13 +57,60 @@ EOF
 systemctl restart sshd 2>/dev/null
 
 if [ $cloud = "aws" -o $cloud = "gcp" -o $cloud = "azure" ]; then
-  echo 127.0.0.1 localhost >/etc/hosts
-  for i in $(seq 1 $clusters); do
-    echo 192.168.$[100+$i].90 master-$i >>/etc/hosts
-    for j in $(seq 1 ${clusternodes[$i]}); do
-      echo 192.168.$[100+$i].$[100+$j] node-$i-$j >>/etc/hosts
+  # Check if using existing VPC (dynamic IPs) - query AWS API like vSphere does
+  if [ $cloud = "aws" ] && [ -n "$aws_existing_vpc_id" ]; then
+    # Install unzip if not present (required for AWS CLI installation)
+    if ! command -v unzip &> /dev/null; then
+      while ! dnf install -y unzip; do sleep 1; done
+    fi
+
+    # Install AWS CLI if not present
+    if ! command -v aws &> /dev/null; then
+      curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+      unzip -q /tmp/awscliv2.zip -d /tmp
+      /tmp/aws/install
+    fi
+
+    # Configure AWS credentials
+    mkdir -p /root/.aws
+    cp /tmp/credentials /root/.aws/credentials
+
+    # Wait for all instances to be running and query their IPs
+    while :; do
+      sleep 1
+      rm -f /tmp/hosts
+
+      # Query EC2 for all instances with our pxd_uuid tag
+      instances=$(aws ec2 describe-instances \
+        --region $aws_region \
+        --filters "Name=tag:pxd_uuid,Values=$pxd_uuid" \
+                  "Name=instance-state-name,Values=running" \
+        --query 'Reservations[].Instances[].[PrivateIpAddress,Tags[?Key==`Name`].Value|[0]]' \
+        --output text)
+
+      # Build hosts file
+      echo "$instances" | while read ip hostname; do
+        echo "$ip $hostname" >>/tmp/hosts
+      done
+
+      # Check if we have all expected instances (master + nodes for all clusters)
+      expected_count=$[($nodes+1)*$clusters]
+      actual_count=$(cat /tmp/hosts 2>/dev/null | wc -l)
+      [ "$actual_count" -eq "$expected_count" ] && break
     done
-  done
+
+    echo 127.0.0.1 localhost >/etc/hosts
+    cat /tmp/hosts >>/etc/hosts
+  else
+    # Use static IPs (for new VPC or GCP/Azure)
+    echo 127.0.0.1 localhost >/etc/hosts
+    for i in $(seq 1 $clusters); do
+      echo 192.168.$[100+$i].90 master-$i >>/etc/hosts
+      for j in $(seq 1 ${clusternodes[$i]}); do
+        echo 192.168.$[100+$i].$[100+$j] node-$i-$j >>/etc/hosts
+      done
+    done
+  fi
 elif [ $cloud = "vsphere" ]; then
   curl -Ls https://github.com/vmware/govmomi/releases/download/v0.52.0/govc_Linux_x86_64.tar.gz | tar -xzf - -C /usr/bin/
   chmod 755 /usr/bin/govc

--- a/scripts/clusterpair
+++ b/scripts/clusterpair
@@ -3,6 +3,7 @@
 
 AWS_ACCESS_KEY=$(sed -n 's/aws_access_key_id[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
 AWS_SECRET_KEY=$(sed -n 's/aws_secret_access_key[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
+AWS_SESSION_TOKEN=$(sed -n 's/aws_session_token[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
 
 echo "Creating bucket '$DR_BUCKET' in region 'us-east-1', if it does not exist"
 aws s3 mb s3://$DR_BUCKET --region us-east-1

--- a/scripts/dude
+++ b/scripts/dude
@@ -27,6 +27,7 @@ install_backup() {
   BACKUP_POD_IP=$(kubectl get pods -n central -l app=px-backup -o jsonpath='{.items[*].status.podIP}' 2>/dev/null)
   AWS_ACCESS_KEY=$(sed -n 's/aws_access_key_id[ =]*//p' /root/.aws/credentials 2>/dev/null)
   AWS_SECRET_KEY=$(sed -n 's/aws_secret_access_key[ =]*//p' /root/.aws/credentials 2>/dev/null)
+  AWS_SESSION_TOKEN=$(sed -n 's/aws_session_token[ =]*//p' /root/.aws/credentials 2>/dev/null)
   client_secret=$(kubectl get secret --namespace central pxc-backup-secret -o jsonpath={.data.OIDC_CLIENT_SECRET} | base64 --decode)
   pxbackupctl login -s http://$pubIP:$backupPort -u admin -p admin
   pxbackupctl create cloudcredential --aws-access-key $AWS_ACCESS_KEY --aws-secret-key $AWS_SECRET_KEY -e $BACKUP_POD_IP:10002 --orgID default -n s3 -p aws
@@ -85,6 +86,7 @@ if [ $[2*$[$cluster/2]] -eq $cluster ]; then
   UUID=$(kubectl get stc -n portworx -o jsonpath='{.items[].status.clusterUid}')
   AWS_ACCESS_KEY=$(sed -n 's/aws_access_key_id[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
   AWS_SECRET_KEY=$(sed -n 's/aws_secret_access_key[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
+  AWS_SESSION_TOKEN=$(sed -n 's/aws_session_token[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
   echo "Creating bucket '$DR_BUCKET' in region 'us-east-1', if it does not exist"
   aws s3 mb s3://$DR_BUCKET --region us-east-1
   BUCKET_REGION=$(aws s3api get-bucket-location --bucket $DR_BUCKET --output text)

--- a/scripts/eks-multicloud-target
+++ b/scripts/eks-multicloud-target
@@ -28,6 +28,7 @@ done
 UUID=$(kubectl get stc -n portworx -o jsonpath='{.items[].status.clusterUid}')
 S3_ACCESS_KEY=$(sed -n 's/aws_access_key_id[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
 S3_SECRET_KEY=$(sed -n 's/aws_secret_access_key[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
+S3_SESSION_TOKEN=$(sed -n 's/aws_session_token[ =]*//p' /root/.aws/credentials 2>/dev/null | head -1)
 
 S3_BUCKET_REGION=$(aws s3api get-bucket-location --bucket $DR_BUCKET --output text)
 # Region us-east-1 returns "None" instead of the region name

--- a/scripts/helm-backup-apps
+++ b/scripts/helm-backup-apps
@@ -1,5 +1,6 @@
 AWS_ACCESS_KEY=$(sed -n 's/aws_access_key_id[ =]*//p' /root/.aws/credentials 2>/dev/null)
 AWS_SECRET_KEY=$(sed -n 's/aws_secret_access_key[ =]*//p' /root/.aws/credentials 2>/dev/null)
+AWS_SESSION_TOKEN=$(sed -n 's/aws_session_token[ =]*//p' /root/.aws/credentials 2>/dev/null)
 ADMIN_PW=$(kubectl get secret pxcentral-keycloak-http -n central -o jsonpath="{.data.password}" | base64 --decode)
 
 if [ "$platform" = ocp4 ]; then

--- a/terraform/aws/cloud-init.tpl
+++ b/terraform/aws/cloud-init.tpl
@@ -9,6 +9,9 @@ write_files:
      [default]
      aws_access_key_id = ${tpl_aws_access_key_id}
      aws_secret_access_key = ${tpl_aws_secret_access_key}
+     %{ if tpl_aws_session_token != "" ~}
+     aws_session_token = ${tpl_aws_session_token}
+     %{ endif ~}
     path: /tmp/credentials
     permissions: '0600'
   
@@ -22,6 +25,7 @@ runcmd:
 - export aws__gw="${tpl_gw}"
 - export aws__routetable="${tpl_routetable}"
 - export aws__ami="${tpl_ami}"
+- export aws_existing_vpc_id="${tpl_aws_existing_vpc_id}"
 - export cloud="aws"
 - export cluster="${tpl_cluster}"
 - export KUBECONFIG=/root/.kube/config

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -56,6 +56,24 @@ variable "aws_secret_access_key" {
 	type		= string
 }
 
+variable "aws_session_token" {
+	description = "AWS Session Token (optional, for temporary credentials)"
+	type        = string
+	default     = ""
+}
+
+variable "aws_existing_vpc_id" {
+	description = "Existing VPC ID to use instead of creating new one (optional)"
+	type        = string
+	default     = ""
+}
+
+variable "aws_existing_subnet_id" {
+	description = "Existing Subnet ID to use (requires aws_existing_vpc_id, optional)"
+	type        = string
+	default     = ""
+}
+
 data "local_file" "env_script" {
 	filename = "${path.module}/env.sh"
 }

--- a/terraform/vsphere/cloud-init.tpl
+++ b/terraform/vsphere/cloud-init.tpl
@@ -18,6 +18,9 @@ write_files:
      [default]
      aws_access_key_id = ${tpl_aws_access_key_id}
      aws_secret_access_key = ${tpl_aws_secret_access_key}
+     %{ if tpl_aws_session_token != "" ~}
+     aws_session_token = ${tpl_aws_session_token}
+     %{ endif ~}
     path: /tmp/credentials
     permissions: '0600'
   

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -161,12 +161,13 @@ resource "vsphere_virtual_machine" "node" {
 
 resource "local_file" "cloud-init" {
 	for_each =	{for key, value in local.instances: key => value}
-	content = templatefile("${path.module}/cloud-init.tpl", 
+	content = templatefile("${path.module}/cloud-init.tpl",
   {
 	  tpl_priv_key = base64encode(tls_private_key.ssh.private_key_openssh),
     tpl_pub_key = tls_private_key.ssh.public_key_openssh,
     tpl_aws_access_key_id = var.aws_access_key_id
 		tpl_aws_secret_access_key = var.aws_secret_access_key
+		tpl_aws_session_token = var.aws_session_token
 	  tpl_name = each.value.instance_name,
 	  tpl_cluster = each.value.cluster
 	})

--- a/terraform/vsphere/variables.tf
+++ b/terraform/vsphere/variables.tf
@@ -106,3 +106,9 @@ variable "aws_secret_access_key" {
 	description ="AWS Secret Access Key"
 	type		= string
 }
+
+variable "aws_session_token" {
+	description = "AWS Session Token (optional, for temporary credentials)"
+	type        = string
+	default     = ""
+}

--- a/vsphere.go
+++ b/vsphere.go
@@ -239,6 +239,7 @@ func vsphere_create_variables(config *Config) []string {
 	tf_variables = append(tf_variables, "vsphere_cpu = \""+config.Vsphere_Cpu+"\"")
 	tf_variables = append(tf_variables, "aws_access_key_id = \""+config.Aws_Access_Key_Id+"\"")
 	tf_variables = append(tf_variables, "aws_secret_access_key = \""+config.Aws_Secret_Access_Key+"\"")
+	tf_variables = append(tf_variables, "aws_session_token = \""+config.Aws_Session_Token+"\"")
 
 	if (config.Vsphere_Dns != "") && (config.Vsphere_Gw != "") && (config.Vsphere_Node_Ip != "") {
 		tf_variables = append(tf_variables, "vsphere_dns = \""+config.Vsphere_Dns+"\"")


### PR DESCRIPTION
This PR adds comprehensive support for AWS temporary credentials and existing VPC/subnet infrastructure, addressing modern AWS authentication requirements and organizational security policies.

## Features Added

### 1. AWS Session Token Support
- Support for temporary credentials from IAM Identity Center (SSO)
- Support for AWS STS session tokens
- Support for assumed role credentials
- Session tokens flow through entire credential chain: User Input → Config → AWS SDK → Terraform → EC2 → Scripts

### 2. Existing VPC/Subnet Support
- Use existing VPC infrastructure instead of creating new VPC
- Use existing subnet instead of creating new subnet
- Conditional resource creation (VPC, subnet, IGW, route tables)
- Dynamic IP assignment for existing subnets
- Dynamic /etc/hosts generation via AWS API queries

## Files Modified (15 files)

**Core Application (2 files):**
- px-deploy.go: Config struct, CLI flags, env vars, destroy fix
- aws.go: AWS SDK integration, nil pointer handling, IAM key age skip

**Configuration (1 file):**
- defaults.yml: Added aws_session_token, aws_existing_vpc_id, aws_existing_subnet_id

**AWS Terraform (3 files):**
- terraform/aws/variables.tf: New variable definitions
- terraform/aws/main.tf: Conditional resources, dynamic IPs, naming fixes
- terraform/aws/cloud-init.tpl: Pass session token and VPC config

**vSphere Terraform (3 files):**
- terraform/vsphere/variables.tf: Session token variable
- terraform/vsphere/main.tf: Pass session token to cloud-init
- terraform/vsphere/cloud-init.tpl: Conditional session token
- vsphere.go: Terraform variable generation

**Infrastructure Scripts (1 file):**
- infra/all-common: Dynamic /etc/hosts, AWS CLI install, IP queries

**Shell Scripts (4 files):**
- scripts/clusterpair: Parse session token
- scripts/dude: Parse session token (2 locations)
- scripts/eks-multicloud-target: Parse session token
- scripts/helm-backup-apps: Parse session token

## Key Fixes

1. **Destroy command session token loading** (px-deploy.go:1271)
   - Was missing session token when loading credentials from defaults.yml
   - Caused authentication failures during destroy operations

2. **AWS instance naming convention** (terraform/aws/main.tf)
   - Masters: master-N (without instance number)
   - Workers: node-N-M (with instance number)
   - Fixes SSH connection and script compatibility issues

3. **Nil pointer handling** (aws.go:391-412)
   - Handle instances with private-only IPs (no public IP)
   - Required for existing VPC deployments without Internet Gateway

4. **IAM key age check** (aws.go:800-804)
   - Skip check when using temporary credentials
   - Prevents panic with session tokens

## Testing Performed

✅ Successfully deployed with temporary credentials (IAM Identity Center) ✅ Successfully deployed with existing VPC and subnet ✅ All nodes became Ready, Portworx installed successfully ✅ Status and connect commands worked correctly
✅ Destroy command worked with refreshed credentials ✅ Tested across multiple AWS accounts with different SCPs ✅ Backward compatibility verified (works without session token)

## Backward Compatibility

✅ 100% backward compatible - no breaking changes
- Session token is optional (defaults to empty string)
- Existing VPC/subnet fields are optional
- All existing configurations work unchanged
- Static credentials continue to work as before

## Security

✅ No security regressions
- Session tokens never logged
- Session tokens cleared from deployment YAML files
- Credentials file permissions remain 0600
- Follows existing credential handling patterns

## Use Cases Addressed

- Organizations using IAM Identity Center (AWS SSO)
- Organizations with SCP blocking Internet Gateway creation
- Deployments requiring site-to-site VPN connectivity
- Multi-account AWS environments with security policies
- Compliance requirements for temporary credentials